### PR TITLE
Specify emulator-build version in CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,33 +44,36 @@ jobs:
           name: app
           path: app/build/outputs/apk/debug/*.apk
 
-# Disabled until emulator works again. see https://github.com/TeamNewPipe/NewPipe/pull/6560
-#  test-android:
-#    runs-on: macos-latest
-#    strategy:
-#      matrix:
-#        api-level: [21, 29]
-#    steps:
-#      - uses: actions/checkout@v2
-#
-#      - name: set up JDK 8
-#        uses: actions/setup-java@v2
-#        with:
-#          java-version: 8
-#          distribution: "temurin"
-#
-#      - name: Cache Gradle dependencies
-#        uses: actions/cache@v2
-#        with:
-#          path: ~/.gradle/caches
-#          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-#          restore-keys: ${{ runner.os }}-gradle
-#
-#      - name: Run android tests
-#        uses: reactivecircus/android-emulator-runner@v2
-#        with:
-#          api-level: ${{ matrix.api-level }}
-#          script: ./gradlew connectedCheck
+  test-android:
+    # macos has hardware acceleration. See android-emulator-runner action
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        # api-level 16 is min sdk, but throws errors related to desugaring
+        api-level: [ 21 ]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: 8
+          distribution: "temurin"
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Run android tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          # workaround to emulator bug: https://github.com/ReactiveCircus/android-emulator-runner/issues/160
+          emulator-build: 7425822
+          script: ./gradlew connectedCheck
 
 #   sonar:
 #     runs-on: ubuntu-latest


### PR DESCRIPTION
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).

Specify emulator-build version in CI job
Also Remove api level 29 from android ci tests