### PR TITLE
Add Ability To Share Stream URL Externally

### DIFF
--- a/app/src/main/java/org/schabi/newpipelegacy/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipelegacy/fragments/detail/VideoDetailFragment.java
@@ -696,6 +696,18 @@ public class VideoDetailFragment extends BaseStateFragment<StreamInfo>
                             currentInfo.getOriginalUrl());
                 }
                 return true;
+            case R.id.menu_item_share_stream:
+                if (currentInfo != null) {
+                    final Stream stream;
+                    if (currentInfo.getVideoStreams().isEmpty()
+                            && currentInfo.getVideoOnlyStreams().isEmpty()) {
+                        stream = getDefaultAudioStream();
+                    } else {
+                        stream = getSelectedVideoStream();
+                    }
+                    ShareUtils.shareUrl(requireContext(), currentInfo.getName(), stream.getUrl());
+                }
+                return true;
             case R.id.menu_item_openInBrowser:
                 if (currentInfo != null) {
                     ShareUtils.openUrlInBrowser(requireContext(), currentInfo.getOriginalUrl());
@@ -929,10 +941,10 @@ public class VideoDetailFragment extends BaseStateFragment<StreamInfo>
     //////////////////////////////////////////////////////////////////////////*/
 
     private void openBackgroundPlayer(final boolean append) {
-        AudioStream audioStream = currentInfo.getAudioStreams()
-                .get(ListHelper.getDefaultAudioFormat(activity, currentInfo.getAudioStreams()));
+        final AudioStream audioStream = getDefaultAudioStream();
 
-        boolean useExternalAudioPlayer = PreferenceManager.getDefaultSharedPreferences(activity)
+        final boolean useExternalAudioPlayer = PreferenceManager
+                .getDefaultSharedPreferences(activity)
                 .getBoolean(activity.getString(R.string.use_external_audio_player_key), false);
 
         if (!useExternalAudioPlayer && android.os.Build.VERSION.SDK_INT >= 16) {
@@ -1014,6 +1026,20 @@ public class VideoDetailFragment extends BaseStateFragment<StreamInfo>
     @Nullable
     private VideoStream getSelectedVideoStream() {
         return sortedVideoStreams != null ? sortedVideoStreams.get(selectedVideoStreamIndex) : null;
+    }
+
+    /**
+     * Get the stream to play when the current stream is an audio-only stream.
+     *
+     * This is the audio-only equivalent of getSelectedVideoStream,
+     * without the ability for the user to select a custom stream quality.
+     *
+     * @return AudioStream instance according to user settings
+     */
+    private AudioStream getDefaultAudioStream() {
+        final List<AudioStream> audioStreams = currentInfo.getAudioStreams();
+        final int streamIndex = ListHelper.getDefaultAudioFormat(activity, audioStreams);
+        return audioStreams.get(streamIndex);
     }
 
     private void prepareDescription(final Description description) {

--- a/app/src/main/res/menu/video_detail_menu.xml
+++ b/app/src/main/res/menu/video_detail_menu.xml
@@ -25,4 +25,10 @@
         android:orderInCategory="2"
         android:title="@string/open_in_browser"
         app:showAsAction="never"/>
+
+    <item
+        android:id="@+id/menu_item_share_stream"
+        android:orderInCategory="3"
+        android:title="@string/share_stream"
+        app:showAsAction="never"/>
 </menu>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -10,6 +10,7 @@
     <string name="open_in_browser">ਬ੍ਰਾਊਜ਼ਰ ਵਿੱਚ ਖੋਲ੍ਹੋ</string>
     <string name="open_in_popup_mode">ਪੌਪ-ਅਪ ਵਿੱਚ ਖੋਲੋ</string>
     <string name="share">ਸਾਂਝਾ ਕਰੋ</string>
+    <string name="share_stream">ਮੀਡੀਆ URL ਸਾਂਝਾ ਕਰੋ</string>
     <string name="download">ਡਾਊਨਲੋਡ</string>
     <string name="controls_download_desc">ਸਟ੍ਰੀਮ ਫ਼ਾਈਲ ਡਾਊਨਲੋਡ ਕਰੋ</string>
     <string name="search">ਖੋਜੋ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="open_in_browser">Open in browser</string>
     <string name="open_in_popup_mode">Open in popup mode</string>
     <string name="share">Share</string>
+    <string name="share_stream">Share media URL</string>
     <string name="download">Download</string>
     <string name="controls_download_desc">Download stream file</string>
     <string name="search">Search</string>


### PR DESCRIPTION
#### What is it?
- [ ] Bug fix (user facing)
- [x] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
add additional menu item in video detail page to share the URL that would be played in external player

#### Testing apk
Link to actions build debug apk:- (https://github.com/ShareASmile/NewPipe-Legacy-Revo/actions/runs/7358260637/artifacts/1139503587)

if you are not logged into github below is debug apk for testing
[NewpipeLegacyRevo Share stream URL debug.zip](https://github.com/ShareASmile/NewPipe-Legacy-Revo/files/13795011/NewpipeLegacyRevo.Share.stream.URL.debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Thanks @jadkik for the work on it [upstream](https://github.com/jadkik/NewPipe/tree/share-stream-url) this is really useful.