### PR TITLE
Add playlist name and video name in playlist sharing content

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -748,4 +748,10 @@
     <string name="unknown_format">Unknown format</string>
     <string name="unknown_quality">Unknown quality</string>
     <string name="feed_toggle_show_future_items">Show future videos</string>
+    <string name="share_playlist">Share Playlist</string>
+    <string name="share_playlist_with_titles_message">Share playlist with details such as playlist name and video titles or as a simple list of video URLs</string>
+    <string name="share_playlist_with_titles">Share with Titles</string>
+    <string name="share_playlist_with_list">Share URL list</string>
+    <string name="video_details_list_item">- %s: %s</string>
+    <string name="share_playlist_content_details">%s\n%s</string>
 </resources>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bug fix (user facing)
- [x] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Add playlist name and video name in playlist sharing content

    Currently, only a list of videos separated by newline are added in
    the share content.
    This makes it difficult to identify a specific video in a list of
    Urls.
    Used string resources for the sharing content formats.
    Added a confirmation dialog for users to choose between sharing
    playlist formats.
    Added Playlist name as the header and corresponding video name for
    each video Url in following format.

#### Testing apk
[Newpipe-add-playlist-n-video-name-when-share.zip](https://github.com/user-attachments/files/15937243/Newpipe-add-playlist-n-video-name-when-share.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.