### PR TITLE
Update extractor to fix "ios client response not valid error" on basic branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,11 @@ on:
       - dev
       - develop
       - flora
+      - flora-conscrypt
       - revo
+      - revo-conscrypt
       - toss
+      - toss-conscrypt
       - legacy-4.0
     paths-ignore:
       - 'README.md'
@@ -24,8 +27,11 @@ on:
       - dev
       - develop
       - flora
+      - flora-conscrypt
       - revo
+      - revo-conscrypt
       - toss
+      - toss-conscrypt
       - legacy-4.0
     paths-ignore:
       - 'README.md'
@@ -40,8 +46,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/checkout@v4
+      - uses: gradle/wrapper-validation-action@v2
 
       - name: create and checkout branch
         # push events already checked out the branch
@@ -49,7 +55,7 @@ jobs:
         run: git checkout -B ${{ github.head_ref }}
 
       - name: set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: "temurin"
@@ -59,7 +65,7 @@ jobs:
         run: ./gradlew assembleDebug lintDebug --stacktrace -DskipFormatKtlint
 
       - name: Upload APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app
           path: app/build/outputs/apk/debug/*.apk
@@ -73,10 +79,10 @@ jobs:
 #        # api-level 16 is min sdk, but throws errors related to desugaring
 #        api-level: [ 21, 29 ]
 #    steps:
-#      - uses: actions/checkout@v3
+#      - uses: actions/checkout@v4
 #
 #      - name: set up JDK 11
-#        uses: actions/setup-java@v3
+#        uses: actions/setup-java@v4
 #        with:
 #          java-version: 11
 #          distribution: "temurin"
@@ -93,25 +99,25 @@ jobs:
 #   sonar:
 #     runs-on: ubuntu-latest
 #     steps:
-#       - uses: actions/checkout@v3
+#       - uses: actions/checkout@v4
 #         with:
 #           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 # 
 #       - name: Set up JDK 11
-#         uses: actions/setup-java@v3
+#         uses: actions/setup-java@v4
 #         with:
 #           java-version: 11 # Sonar requires JDK 11
 #           distribution: "temurin"
 
 #       - name: Cache SonarCloud packages
-#         uses: actions/cache@v3
+#         uses: actions/cache@v4
 #         with:
 #           path: ~/.sonar/cache
 #           key: ${{ runner.os }}-sonar
 #           restore-keys: ${{ runner.os }}-sonar
 # 
 #       - name: Cache Gradle packages
-#         uses: actions/cache@v3
+#         uses: actions/cache@v4
 #         with:
 #           path: ~/.gradle/caches
 #           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -192,7 +192,7 @@ dependencies {
     // name and the commit hash with the commit hash of the (pushed) commit you want to test
     // This works thanks to JitPack: https://jitpack.io/
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
-    implementation 'com.github.ShareASmile.NewPipeExtractor:NewPipeExtractor:update-ios-client-again-SNAPSHOT'
+    implementation 'com.github.ShareASmile.NewPipeExtractor:NewPipeExtractor:v0.22.7.6'
 
 /** Checkstyle **/
     checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -192,7 +192,7 @@ dependencies {
     // name and the commit hash with the commit hash of the (pushed) commit you want to test
     // This works thanks to JitPack: https://jitpack.io/
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
-    implementation 'com.github.ShareASmile:NewPipeExtractor:0b889c000c99e1f1ba302e9c4310ed0eea585fd0'
+    implementation 'com.github.ShareASmile.NewPipeExtractor:NewPipeExtractor:update-ios-client-again-SNAPSHOT'
 
 /** Checkstyle **/
     checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -184,7 +184,7 @@ sonarqube {
 
 dependencies {
 /** Desugaring **/
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_nio:2.0.3'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_nio:2.0.4'
 
 /** NewPipe libraries **/
     // You can use a local version by uncommenting a few lines in settings.gradle

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         resValue "string", "app_name", "NewPipe"
         minSdk 16
         targetSdk 29
-        versionCode 988
-        versionName "0.23.2"
+        versionCode 989
+        versionName "0.23.3"
 
         multiDexEnabled true
 
@@ -192,7 +192,7 @@ dependencies {
     // name and the commit hash with the commit hash of the (pushed) commit you want to test
     // This works thanks to JitPack: https://jitpack.io/
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
-    implementation 'com.github.RSoulwin:NewPipeExtractor:d731ca24559172813df0fdebcbf10239cc26d6fc'
+    implementation 'com.github.ShareASmile:NewPipeExtractor:0b889c000c99e1f1ba302e9c4310ed0eea585fd0'
 
 /** Checkstyle **/
     checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the PR

Note1:

This basic branch has somewhat Updated AGP to 7.4.0, Gradle to 7.5.1 and other libraries required for desugaring library update to desugar properly the latest methods used in NewPipe Extractor we need minimum version nio_2.0.4 of this library to desugar those methods. So I have updated it to 2.0.4 in this PR along with updating the legacy extractor and also updated gh actions libraries to v4 using node 20.

Note2: Or We can use JDK8 version of extractor or UTF_8 instead of StandardCharsets.UTF_8 because StandardCharsets.UTF_8 does not get desugared to UTF_8 by desugaring library 1.1.6

Note3: basic branch uses conscrypt provider & uses tls 1.2 & 1.3 protocols Hence it should be tested throughly on actual devices whether it works on actual devices.

#### Fixes the following issue(s)

- Fixes 2nd occurrence of "ios response not valid" error on NewPipe Legacy basic by updating to legacy extractor v0.22.7.6 & made it compatible for old devices by using desugar_jdk_libs_nio_2.0.4 version

#### Relies on the following changes
<!-- Delete this if it doesn't apply to you. -->
- 

#### APK testing:
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

[NewPipe_basic-fix-debug.zip](https://github.com/user-attachments/files/18644640/NewPipe_basic-fix-debug.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
